### PR TITLE
make REDIRECTIONS local in update_upnp

### DIFF
--- a/docker-image/update_upnp
+++ b/docker-image/update_upnp
@@ -4,6 +4,7 @@ update_upnp()
 {
     APP_NAME=$1
     shift
+    local REDIRECTIONS=""
     while (( "$#" )); do
         REDIRECTIONS="$REDIRECTIONS $1"
         shift


### PR DESCRIPTION
Fixes an issue where the redirections from the previous app get carried over to the next app and eventually all the redirections are titled after the last app.

Sorry about the last line, GitHub forced it.