### PR TITLE
Added "-z localport" option to upnpc command to fix "No IGD UPnP Device found on the network !" on certain networks

### DIFF
--- a/docker-image/update_upnp
+++ b/docker-image/update_upnp
@@ -15,9 +15,9 @@ update_upnp()
     GATEWAY=$(ip route | head -1 | awk '{print $3}')
     printf '%s\n' "Detected gateway is [$GATEWAY]"
 
-    upnpc -e "$APP_NAME" -r $REDIRECTIONS
-
-    printf '%s\n' "Done updating UPnP entry with port redirections [$REDIRECTIONS]"
+    upnpc -z 1900 -e "$APP_NAME" -r $REDIRECTIONS \
+    && printf '%s\n' "Done updating UPnP entry with port redirections [$REDIRECTIONS]" \
+    || printf '%s\n' "Error updating UPnP entry with port redirections [$REDIRECTIONS]"
 }
 
 MASTER_CONFIG_DIR="/etc/upnp-service"


### PR DESCRIPTION
Update update_upnp:
- added "-z localport" option to upnpc command to fix "No IGD UPnP Device found on the network !" on certain networks (see [this issue](https://github.com/ProjectInitiative/upnp-service/issues/5))
- also added return of error message if upnpc command fails (on current version a "success" message is returned even if the command fails)

